### PR TITLE
Fix GetFeatureInfoCSSFilter class name

### DIFF
--- a/filters/GetFeatureInfoCSSFilter.py
+++ b/filters/GetFeatureInfoCSSFilter.py
@@ -22,10 +22,10 @@
 
 from qgis.server import *
 
-class GetFeatureInfoFilter(QgsServerFilter):
+class GetFeatureInfoCSSFilter(QgsServerFilter):
 
     def __init__(self, serverIface):
-        super(GetFeatureInfoFilter, self).__init__(serverIface)
+        super(GetFeatureInfoCSSFilter, self).__init__(serverIface)
 
     def responseComplete(self):
         handler = self.serverInterface().requestHandler()


### PR DESCRIPTION
The code looks at the file names to deduce class names. The file is named `GetFeatureInfoCSSFilter.py` so the code was looking for `GetFeatureInfoCSSFilter` as class. The class was named `GetFeatureInfoFilter` (no "CSS"). This led to the following error:

```
../../src/server/qgsserverplugins.cpp:74 : (initPlugins) [0ms] Python support library's instance() symbol resolved.
../../src/server/qgsserverplugins.cpp:80 : (initPlugins) [302ms] Python support ENABLED :-)
../../src/core/qgsmessagelog.cpp:29 : (logMessage) [23ms] 2021-12-21T11:20:35 plugin[0] SUCCESS - HelloServer init
HelloServerServer - loading filter ParamsFilter
HelloServerServer - loading filter GetFeatureInfoCSSFilter
HelloServerServer - Error loading filter GetFeatureInfoCSSFilter : module 'qgis-helloserver.filters' has no attribute 'GetFeatureInfoCSSFilter'
HelloServerServer - loading filter ExceptionFilter
HelloServerServer - loading filter HelloFilter
HelloServerServer - loading filter WatermarkFilter
```