### PR TITLE
Make parameter lookup not crash if not specified

### DIFF
--- a/filters/WatermarkFilter.py
+++ b/filters/WatermarkFilter.py
@@ -35,8 +35,8 @@ class WatermarkFilter(QgsServerFilter):
         request = self.serverInterface().requestHandler()
         params = request.parameterMap( )
         # Do some checks
-        if (params.get('SERVICE').upper() == 'WMS' \
-                and params.get('REQUEST').upper() == 'GETMAP' \
+        if (params.get('SERVICE', '').upper() == 'WMS' \
+                and params.get('REQUEST', '').upper() == 'GETMAP' \
                 and not request.exceptionRaised() ):
             QgsMessageLog.logMessage("WatermarkFilter.responseComplete: image ready %s" % request.parameter("FORMAT"))
             # Get the image


### PR DESCRIPTION
When trying to access an endpoint for WFS3 (OGC API Features) while the plugin is active, the plugin will crash and the response will fail:

```
../../src/core/qgsmessagelog.cpp:29 : (logMessage) [0ms] 2021-12-21T12:14:38 Server[0] API OGC WFS3 (Draft): found handler getLandingPage
../../src/core/qgsmessagelog.cpp:29 : (logMessage) [3ms] 2021-12-21T12:14:38 [1] SUCCESS - ParamsFilter.responseComplete
../../src/core/qgsmessagelog.cpp:29 : (logMessage) [0ms] 2021-12-21T12:14:38 [1] HelloFilter.responseComplete
../../src/core/qgsmessagelog.cpp:29 : (logMessage) [0ms] 2021-12-21T12:14:38 Server[2] 'NoneType' object has no attribute 'upper'
```

This is due to a missing default value for parameter lookups in the WatermarkFilter.